### PR TITLE
Converted to Vanilla JS / Fixed close button bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Updates
 -------
 * 02/08/16 - Initial Commit
 * 03/02/16 - Added more Q&A
+* 03/22/21:
+  * Code converted to Vanilla JavaScript so it can be compatible with multiple themes (Copenhagen v2.+ doesn't support jQuery anymore)
+  * Fixed "close" button not showing properly issue
 
 
 Todays Menu
@@ -23,7 +26,7 @@ Todays Menu
 * API
 * CSS
 * HTML
-* JS/JQuery
+* JS
 * Entypo font icons or FontAwesome (default uses Entypo)
 
 How to Install
@@ -70,16 +73,20 @@ Edit the color in this statement (near the top of the css)
 ```
 ### How do I define the article label which controls the notification?
 
-Change names=alert on the line below to anything you would like.
+Change the `label` variable on the line below to anything you would like.
 
-> $.get( "https://yourdomain.zendesk.com/api/v2/help_center/articles.json?label_names=alert" ).done(function( data ) {
+```
+// Article label to be considered for the alerts
+const label = 'alert'
+```
 
 ### How do I remove the article title or article body?
 
-You can edit the line below (to remove the body remove the +item.body+)
+You can edit the line below and set `showArticleBody` to `false`
 
 ```
-<a href="'+ item.html_url + '">' + item.title + '</a>' + item.body + '</p>
+// Show the article body within the alertbox? (Boolean: true/false)
+const showArticleBody = true
 ```
 ### How do I use a different icon?
 

--- a/zendesk.css
+++ b/zendesk.css
@@ -4,6 +4,7 @@
 /* change the background color by editing "background"  */
 /* change the text color by editing "color"  */
 .ns-box {
+	position: relative;
 	background: rgba(192, 57, 43,0.85);
 	padding: 10px 20px 20px 20px;
 	line-height: 1.4;
@@ -51,7 +52,7 @@
 	backface-visibility: hidden;
 }
 
-.ns-close:hover, 
+.ns-close:hover,
 .ns-close:focus {
 	outline: none;
 }
@@ -87,7 +88,7 @@
     font-size: 3.8em;
 }
 
-.megaphone:before { 
+.megaphone:before {
   content:'\1F4E3';
   font-family: "entypo";
   font-size: 2.2em;

--- a/zendesk.js
+++ b/zendesk.js
@@ -1,14 +1,54 @@
-  // MW-Notification Banner
-   $.get( "/api/v2/help_center/"+$('html').attr('lang').toLowerCase()+"/articles.json?label_names=alert" ).done(function( data ) {
-     
-   $.each(data.articles, function(index,item) {
-     
-     var style1 = '<div class="ns-box ns-bar ns-effect-slidetop ns-type-notice ns-show"><div class="ns-box-inner"><span class="megaphone"></span></i><p><a href="'+ item.html_url + '">' + item.title + '</a>' + item.body + '</p></div><span class="ns-close"></span></div>'
-           
-     $('.alertbox').append(style1);
-   });
-   $('.ns-close').on('click',function(){
-    $(".alertbox").remove();
-  });
-    
-  });
+// MW-Notification Banner
+document.addEventListener('DOMContentLoaded', async function () {
+  // Article label to be considered for the alerts
+  const label = 'alert'
+
+  // Show the article body within the alertbox? (Boolean: true/false)
+  const showArticleBody = true
+
+  // Get current help center locale
+  const locale = document
+    .querySelector('html')
+    .getAttribute('lang')
+    .toLowerCase()
+
+  // URL to be called to get the alert data
+  const url = `/api/v2/help_center/${locale}/articles.json?label_names=${label}`
+
+  // Raw data collected from the endpoint above
+  const data = await (await fetch(url)).json()
+
+  // List of articles returned
+  const articles = (data && data.articles) || []
+
+  // Handle returned articles
+  for (let i = 0; i < articles.length; i++) {
+    const url = articles[i].html_url
+    const title = articles[i].title
+    const body = articles[i].body
+
+    const html = `
+      <div class="ns-box ns-bar ns-effect-slidetop ns-type-notice ns-show">
+        <div class="ns-box-inner">
+          <span class="megaphone"></span>
+          <p>
+            <a href="${url}">${title}</a>
+            ${showArticleBody ? body : ''}
+          </p>
+        </div>
+        <span class="ns-close"></span>
+      </div>
+    `
+
+    // Append current alert to the alertbox container
+    document.querySelector('.alertbox').insertAdjacentHTML('beforeend', html)
+  }
+})
+
+document.addEventListener('click', function (event) {
+  // Close alertbox
+  if (event.target.matches('.ns-close')) {
+    event.preventDefault()
+    event.target.parentElement.remove()
+  }
+})


### PR DESCRIPTION
Hi Wes, I noticed that this project uses jQuery, and since Copenhagen 2.+ doesn't support jQuery anymore, I'd like to add these suggestions so it can be compatible with newer help centers too. I also fixed a bug that was making the "close button" invisible for multiple alerts or when the Zendesk agent panel was open.  Hope it helps!